### PR TITLE
Removing support of process_p2m_lookup

### DIFF
--- a/doma.xml
+++ b/doma.xml
@@ -46,7 +46,7 @@
 
   <!-- Internal projects -->
   <project path="vendor/imagination/rogue_um" name="pvr_um_vgpu_img" groups="notdefault" remote="epam" revision="1.11/5375571-7.1.0-10.0.0_r3-xt0.1-prebuilds"/>
-  <project path="vendor/imagination/rogue_km" name="pvr_km_vgpu_img" groups="notdefault" remote="epam" revision="1.11/5375571-7.1.0-10.0.0_r3-xt0.1" />
+  <project path="vendor/imagination/rogue_km" name="pvr_km_vgpu_img" groups="notdefault" remote="epam" revision="1.11/5375571-7.1.0-10.0.0_r3-xt0.2" />
   <project path="prebuilts/imagination/metag/2.8" name="android_meta_embedded_toolkit" groups="notdefault" remote="epam" revision="master" />
   <project path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-gnu" name="android_prebuilds_gcc_linuxx86_aarch64" groups="notdefault" remote="epam" revision="linaro-7.3.1" />
   <project path="vendor/Google" name="google_apps_proprietary" groups="notdefault" remote="epam" revision="master" />


### PR DESCRIPTION
Switch the branch of pvr_km_vgpu_img at the cleaned revision
"1.11/5375571-7.1.0-10.0.0_r3-xt0.2".

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>