### PR TITLE
Change trout device descriptor repository protocol.

### DIFF
--- a/aosp-device-xenvm-trout.xml
+++ b/aosp-device-xenvm-trout.xml
@@ -1,4 +1,4 @@
 <manifest>
-    <remote name="github" fetch="ssh://git@github.com"/>
+    <remote name="github" fetch="https://github.com/"/>
     <project path="device/epam/aosp-xenvm-trout" name="xen-troops/android_device_epam_xenvm-trout" remote="github" revision="android-14.0.0_r21-xenvm-trout-main"/>
 </manifest>


### PR DESCRIPTION
Switch to using HTTPS instead of SSH. This will allow users without GitHub registration to clone the repository.

Change-Id: I29677f69f9e77bb016dc1387b38de3694ad24eb4