### PR TITLE
Add lisot repository to Android

### DIFF
--- a/aosp-device-xenvm-trout.xml
+++ b/aosp-device-xenvm-trout.xml
@@ -3,4 +3,5 @@
     <remote name="fd" fetch="https://gitlab.freedesktop.org/"/>
     <project path="device/epam/aosp-xenvm-trout" name="xen-troops/android_device_epam_xenvm-trout" remote="github" revision="31e3459a791ef8fd2250e6a39e89baf918a57a05"/>
     <project path="external/mesa3d_upstream" name="mesa/mesa" remote="fd" revision="e3f91fb13c70bff9bc361b78439293d6288084a1"/>
+    <project path="vendor/epam/lisot" name="xen-troops/lisot" remote="github" revision="ea3da7cd2fd18059701ea67293d96f797f9ac39b"/>
 </manifest>


### PR DESCRIPTION
Add the lisot repository to the manifest so we
can test vhost-vsock on Android.