### PR TITLE
Point to branch for device descriptor

### DIFF
--- a/aosp-device-xenvm-trout.xml
+++ b/aosp-device-xenvm-trout.xml
@@ -1,7 +1,7 @@
 <manifest>
     <remote name="github" fetch="https://github.com/"/>
     <remote name="fd" fetch="https://gitlab.freedesktop.org/"/>
-    <project path="device/epam/aosp-xenvm-trout" name="xen-troops/android_device_epam_xenvm-trout" remote="github" revision="31e3459a791ef8fd2250e6a39e89baf918a57a05"/>
+    <project path="device/epam/aosp-xenvm-trout" name="xen-troops/android_device_epam_xenvm-trout" remote="github" revision="android-15-xenvm-trout-ih-main"/>
     <project path="external/mesa3d_upstream" name="mesa/mesa" remote="fd" revision="e3f91fb13c70bff9bc361b78439293d6288084a1"/>
     <project path="vendor/epam/lisot" name="xen-troops/lisot" remote="github" revision="ea3da7cd2fd18059701ea67293d96f797f9ac39b"/>
 </manifest>


### PR DESCRIPTION
Point to a dedicated branch for the device descriptor until the next release, to avoid repeatedly
overcommitting patches required for each revision change.